### PR TITLE
Auto render

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,29 @@
+name: main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Render:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Render template
+        uses: andrewthetechie/gha-cookiecutter@main
+        with:
+          template: .
+          cookiecutterValues: '{ "app_name": "example", "description": "An example cookiecutter-python repository" }'
+
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          target-branch: main
+          source-directory: example
+          destination-github-username: parrot-com
+          destination-repository-name: cookiecutter-python-example


### PR DESCRIPTION
this PR renders cookiecutter on merge to `main` into https://github.com/parrot-com/cookiecutter-python-example (repository already has something pushed)

I wanted to go for "render current branch to a remote branch with same name post link back to the PR" but I couldn't find a gh action which would allow that.. unfortunately `cpina/github-action-push-to-another-repository` needs the target branch to already exist and doesn't provide any output (if it returned commit hash, we could add link)

any ideas on how to improve this?