### PR TITLE
Add sentry and helm manual steps into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ You need to manually perform the following steps:
 1. create a GitHub repository
 1. create a Sentry project
     * TODO: set env variables
+    * trigger error on staging and production and then create [alert rules](https://docs.sentry.io/product/integrations/notification-incidents/slack/) to our monitoring channels on Slack
 1. create ECR repository
 1. TODO: add k8s manifests
+    * set Helm chart env variables (you will probably want to set `APP_ENV` or similar variable when the project is used in multiple environments)
 
 ## TODO
 


### PR DESCRIPTION
I had to do these manual steps for `document-generator` so I am putting them into README so we do not forget to do them next time.